### PR TITLE
Pr/offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,86 @@ The app runs **100% in your browser** — your data never leaves your machine. I
 
 ![New Conditional Access Policy Analyzer](docs/screenshots/CondtionalAccessAnalyzer.png)
 
+### Offline Mode (No Direct Tenant Access)
+
+You can run analysis fully offline by exporting Entra data once, moving the JSON file to an offline machine, and using **Import Offline Export** on the sign-in screen.
+
+#### 1) Export from an online/admin workstation (PowerShell)
+
+```powershell
+# Install only required Microsoft Graph submodules
+Install-Module Microsoft.Graph.Authentication -Scope CurrentUser
+Install-Module Microsoft.Graph.Beta.Identity.SignIns -Scope CurrentUser
+Install-Module Microsoft.Graph.Applications -Scope CurrentUser
+Install-Module Microsoft.Graph.Identity.DirectoryManagement -Scope CurrentUser
+
+Import-Module Microsoft.Graph.Authentication
+Import-Module Microsoft.Graph.Beta.Identity.SignIns
+Import-Module Microsoft.Graph.Applications
+Import-Module Microsoft.Graph.Identity.DirectoryManagement
+
+Connect-MgGraph -Scopes `
+  "Policy.Read.All", `
+  "Application.Read.All", `
+  "Directory.Read.All", `
+  "Policy.Read.ConditionalAccess", `
+  "Organization.Read.All"
+
+$tenant = Get-MgOrganization -Top 1
+$policies = Get-MgBetaIdentityConditionalAccessPolicy -All
+$namedLocations = Get-MgIdentityConditionalAccessNamedLocation -All
+$servicePrincipals = Get-MgServicePrincipal -All -Property "id,appId,displayName,servicePrincipalType,appOwnerOrganizationId,tags"
+$authStrengthPolicies = Get-MgBetaPolicyAuthenticationStrengthPolicy -All
+$subscribedSkus = Get-MgSubscribedSku -All
+
+# Resolve policy-referenced directory objects (users/groups/roles) for friendly names
+$objectIds = [System.Collections.Generic.HashSet[string]]::new()
+foreach ($p in $policies) {
+  $u = $p.Conditions.Users
+  foreach ($id in @($u.IncludeUsers + $u.ExcludeUsers + $u.IncludeGroups + $u.ExcludeGroups + $u.IncludeRoles + $u.ExcludeRoles)) {
+    if ($id -match '^[0-9a-fA-F-]{36}$') { [void]$objectIds.Add($id) }
+  }
+}
+
+$directoryObjects = foreach ($id in $objectIds) {
+  try { Get-MgDirectoryObject -DirectoryObjectId $id -ErrorAction Stop } catch { $null }
+}
+
+$export = [ordered]@{
+  tenantId                      = $tenant.Id
+  tenantDisplayName             = $tenant.DisplayName
+  conditionalAccessPolicies     = $policies
+  namedLocations                = $namedLocations
+  servicePrincipals             = $servicePrincipals
+  directoryObjects              = $directoryObjects
+  authenticationStrengthPolicies= $authStrengthPolicies
+  subscribedSkus                = $subscribedSkus
+}
+
+$export | ConvertTo-Json -Depth 25 | Out-File ".\ca-offline-export.json" -Encoding utf8
+```
+
+#### 2) Import offline
+
+1. Open CA Policy Analyzer.
+2. On the sign-in screen, click **Import Offline Export**.
+3. Select `ca-offline-export.json`.
+4. Run analysis normally (Dashboard, Findings, Templates, CIS, Personas, Baseline Gap, exports all work).
+
+#### Regression fixture (PowerShell export shape)
+
+For parser regression checks, a canonical fixture using the PowerShell v2/Beta export structure is included at:
+
+- `docs/fixtures/offline-export-powershell-v2-shape.json`
+
+This fixture intentionally includes edge cases that previously caused offline/live mismatches:
+
+- `conditionalAccessPolicies` as a single object (not array)
+- `PascalCase` keys
+- `AdditionalProperties` wrappers
+- null-valued `IncludeLocations` / `ExcludeLocations`
+- null placeholder guest/auth-strength objects
+
 ---
 
 ## Recent Changes

--- a/docs/fixtures/offline-export-powershell-v2-shape.json
+++ b/docs/fixtures/offline-export-powershell-v2-shape.json
@@ -1,0 +1,113 @@
+{
+  "tenantId": "00000000-0000-0000-0000-000000000000",
+  "tenantDisplayName": "Fixture Tenant",
+  "conditionalAccessPolicies": {
+    "Id": "11111111-1111-1111-1111-111111111111",
+    "DisplayName": "Fixture - MFA for all users",
+    "State": "enabled",
+    "CreatedDateTime": "2026-01-01T00:00:00Z",
+    "ModifiedDateTime": null,
+    "Conditions": {
+      "Applications": {
+        "IncludeApplications": ["All"],
+        "ExcludeApplications": [],
+        "IncludeUserActions": [],
+        "IncludeAuthenticationContextClassReferences": []
+      },
+      "ClientAppTypes": ["all"],
+      "Locations": {
+        "IncludeLocations": null,
+        "ExcludeLocations": null
+      },
+      "Platforms": {
+        "IncludePlatforms": null,
+        "ExcludePlatforms": null
+      },
+      "Users": {
+        "IncludeUsers": ["All"],
+        "ExcludeUsers": [],
+        "IncludeGroups": [],
+        "ExcludeGroups": [],
+        "IncludeRoles": [],
+        "ExcludeRoles": [],
+        "IncludeGuestsOrExternalUsers": {
+          "GuestOrExternalUserTypes": null,
+          "ExternalTenants": {
+            "MembershipKind": null
+          }
+        },
+        "ExcludeGuestsOrExternalUsers": {
+          "GuestOrExternalUserTypes": null,
+          "ExternalTenants": {
+            "MembershipKind": null
+          }
+        }
+      },
+      "SignInRiskLevels": [],
+      "UserRiskLevels": []
+    },
+    "GrantControls": {
+      "Operator": "OR",
+      "BuiltInControls": ["mfa"],
+      "CustomAuthenticationFactors": [],
+      "TermsOfUse": [],
+      "AuthenticationStrength": {
+        "Id": null,
+        "DisplayName": null
+      }
+    },
+    "AdditionalProperties": {
+      "templateId": "4200930c-0da2-4e33-ca02-000000000004"
+    }
+  },
+  "namedLocations": [
+    {
+      "Id": "22222222-2222-2222-2222-222222222222",
+      "DisplayName": "Trusted IPs",
+      "AdditionalProperties": {
+        "@odata.type": "#microsoft.graph.ipNamedLocation",
+        "isTrusted": true,
+        "ipRanges": [
+          {
+            "cidrAddress": "203.0.113.0/24"
+          }
+        ]
+      }
+    }
+  ],
+  "servicePrincipals": [
+    {
+      "Id": "33333333-3333-3333-3333-333333333333",
+      "AppId": "44444444-4444-4444-4444-444444444444",
+      "DisplayName": "Fixture App",
+      "ServicePrincipalType": "Application",
+      "Tags": []
+    }
+  ],
+  "directoryObjects": {
+    "Id": "55555555-5555-5555-5555-555555555555",
+    "AdditionalProperties": {
+      "@odata.type": "#microsoft.graph.directoryRoleTemplate",
+      "displayName": "Directory Synchronization Accounts"
+    }
+  },
+  "authenticationStrengthPolicies": [
+    {
+      "Id": "66666666-6666-6666-6666-666666666666",
+      "DisplayName": "Multifactor authentication strength",
+      "Description": "Fixture policy",
+      "PolicyType": "builtIn",
+      "AllowedCombinations": ["password,microsoftAuthenticatorPush"],
+      "RequirementsSatisfied": "mfa"
+    }
+  ],
+  "subscribedSkus": [
+    {
+      "servicePlans": [
+        {
+          "servicePlanId": "41781fb2-bc02-4b7c-bd55-b576c07bb09d"
+        }
+      ]
+    }
+  ]
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" className="dark" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-950 text-gray-100`}
       >

--- a/src/app/offline-export/page.tsx
+++ b/src/app/offline-export/page.tsx
@@ -1,0 +1,90 @@
+export default function OfflineExportGuidePage() {
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div className="rounded-xl border border-gray-800 bg-gray-900 p-6">
+        <h2 className="text-2xl font-bold text-white">Offline Export Guide</h2>
+        <p className="mt-2 text-sm text-gray-400">
+          Use this workflow when CA Policy Analyzer cannot access Microsoft Graph directly.
+          Export once from an online admin workstation, then import the JSON file into offline mode.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-gray-800 bg-gray-900 p-6 space-y-4">
+        <h3 className="text-lg font-semibold text-white">1) Prepare PowerShell</h3>
+        <p className="text-sm text-gray-400">
+          Run these commands on a workstation that can reach Microsoft Graph.
+          This installs only the required submodules.
+        </p>
+        <pre className="overflow-x-auto rounded-lg border border-gray-800 bg-gray-950 p-4 text-xs text-gray-300">
+{`Install-Module Microsoft.Graph.Authentication -Scope CurrentUser
+Install-Module Microsoft.Graph.Beta.Identity.SignIns -Scope CurrentUser
+Install-Module Microsoft.Graph.Applications -Scope CurrentUser
+Install-Module Microsoft.Graph.Identity.DirectoryManagement -Scope CurrentUser
+
+Import-Module Microsoft.Graph.Authentication
+Import-Module Microsoft.Graph.Beta.Identity.SignIns
+Import-Module Microsoft.Graph.Applications
+Import-Module Microsoft.Graph.Identity.DirectoryManagement`}
+        </pre>
+      </div>
+
+      <div className="rounded-xl border border-gray-800 bg-gray-900 p-6 space-y-4">
+        <h3 className="text-lg font-semibold text-white">2) Run export script</h3>
+        <p className="text-sm text-gray-400">
+          This creates a single file named <code>ca-offline-export.json</code> with
+          all required datasets.
+        </p>
+        <pre className="overflow-x-auto rounded-lg border border-gray-800 bg-gray-950 p-4 text-xs text-gray-300">
+{`Connect-MgGraph -Scopes \`
+  "Policy.Read.All", \`
+  "Application.Read.All", \`
+  "Directory.Read.All", \`
+  "Policy.Read.ConditionalAccess", \`
+  "Organization.Read.All"
+
+$tenant = Get-MgOrganization -Top 1
+$policies = Get-MgBetaIdentityConditionalAccessPolicy -All
+$namedLocations = Get-MgIdentityConditionalAccessNamedLocation -All
+$servicePrincipals = Get-MgServicePrincipal -All -Property "id,appId,displayName,servicePrincipalType,appOwnerOrganizationId,tags"
+$authStrengthPolicies = Get-MgBetaPolicyAuthenticationStrengthPolicy -All
+$subscribedSkus = Get-MgSubscribedSku -All
+
+$objectIds = [System.Collections.Generic.HashSet[string]]::new()
+foreach ($p in $policies) {
+  $u = $p.Conditions.Users
+  foreach ($id in @($u.IncludeUsers + $u.ExcludeUsers + $u.IncludeGroups + $u.ExcludeGroups + $u.IncludeRoles + $u.ExcludeRoles)) {
+    if ($id -match '^[0-9a-fA-F-]{36}$') { [void]$objectIds.Add($id) }
+  }
+}
+
+$directoryObjects = foreach ($id in $objectIds) {
+  try { Get-MgDirectoryObject -DirectoryObjectId $id -ErrorAction Stop } catch { $null }
+}
+
+$export = [ordered]@{
+  tenantId                       = $tenant.Id
+  tenantDisplayName              = $tenant.DisplayName
+  conditionalAccessPolicies      = $policies
+  namedLocations                 = $namedLocations
+  servicePrincipals              = $servicePrincipals
+  directoryObjects               = $directoryObjects
+  authenticationStrengthPolicies = $authStrengthPolicies
+  subscribedSkus                 = $subscribedSkus
+}
+
+$export | ConvertTo-Json -Depth 25 | Out-File ".\\ca-offline-export.json" -Encoding utf8`}
+        </pre>
+      </div>
+
+      <div className="rounded-xl border border-gray-800 bg-gray-900 p-6 space-y-3">
+        <h3 className="text-lg font-semibold text-white">3) Import into analyzer</h3>
+        <ol className="list-decimal space-y-2 pl-5 text-sm text-gray-300">
+          <li>Open CA Policy Analyzer.</li>
+          <li>On the landing screen, click <strong>Import Offline Export</strong>.</li>
+          <li>Select <code>ca-offline-export.json</code>.</li>
+          <li>Run analysis as usual.</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import { useIsAuthenticated, useMsal } from "@azure/msal-react";
 import { loadTenantContext, TenantContext } from "@/lib/graph-client";
 import { analyzeAllPolicies, AnalysisResult, calculateCompositeScore, CompositeScoreResult } from "@/lib/analyzer";
@@ -51,10 +51,18 @@ export default function Home() {
   const [baselineCategory, setBaselineCategory] = useState<TemplateCategory | null>(null);
   const [logoBase64, setLogoBase64] = useState<string | null>(null);
 
-  const setAppMode = useCallback((mode: "offline" | "live") => {
-    localStorage.setItem("caAnalyzerMode", mode);
+  const setAppMode = useCallback((mode: "offline" | "live" | null) => {
+    if (mode === null) {
+      localStorage.removeItem("caAnalyzerMode");
+    } else {
+      localStorage.setItem("caAnalyzerMode", mode);
+    }
     window.dispatchEvent(new CustomEvent("ca-analyzer-mode", { detail: mode }));
   }, []);
+
+  useEffect(() => {
+    if (!result) setAppMode(null);
+  }, [result, setAppMode]);
 
   const executeAnalysis = useCallback(async (ctx: TenantContext) => {
     setContext(ctx);
@@ -209,9 +217,19 @@ export default function Home() {
       }
       const text = await file.text();
       const parsed = JSON.parse(text) as OfflineExportPayload;
+
+      const asAny = parsed as Record<string, unknown>;
+      if (asAny.policyResults !== undefined || asAny.findings !== undefined || asAny.overallScore !== undefined) {
+        throw new Error(
+          "This looks like an analysis results export, not a raw policy export. " +
+          "To use offline mode, export your policies directly from PowerShell using " +
+          "Get-MgIdentityConditionalAccessPolicy | ConvertTo-Json -Depth 10, then upload that file."
+        );
+      }
+
       const ctx = buildTenantContextFromOfflineExport(parsed);
       if (ctx.policies.length === 0) {
-        throw new Error("No Conditional Access policies found in the uploaded JSON export.");
+        throw new Error("No Conditional Access policies found. Make sure you're uploading a raw Graph PowerShell export (Get-MgIdentityConditionalAccessPolicy | ConvertTo-Json -Depth 10).");
       }
       setAppMode("offline");
       await executeAnalysis(ctx);
@@ -261,9 +279,6 @@ export default function Home() {
         </p>
         <div className="mt-8 grid w-full max-w-4xl gap-4 text-left md:grid-cols-2">
           <div className="rounded-xl border border-blue-500/30 bg-blue-500/5 p-5">
-            <div className="mb-2 inline-flex rounded-full border border-blue-500/30 bg-blue-500/10 px-2.5 py-1 text-xs font-medium text-blue-300">
-              Recommended
-            </div>
             <p className="text-sm font-medium text-gray-100">Offline export import</p>
             <p className="mt-1 text-xs text-gray-400">
               Default mode for least privilege and fully offline analysis. Export once, then upload JSON.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,10 +22,13 @@ import { analyzeBaselineGaps, BaselineGapResult } from "@/lib/baseline-gap";
 import { TemplateCategory } from "@/data/policy-templates";
 import { BaselineGapView } from "@/components/baseline-gap-view";
 import { exportToExcel, exportToPowerPoint, loadDefaultLogo } from "@/lib/export-utils";
+import { buildTenantContextFromOfflineExport, OfflineExportPayload } from "@/lib/offline-import";
+import { loginRequest } from "@/lib/msal-config";
 import { Shield, Loader2, Play, Download, RefreshCw, LayoutDashboard, FileText, AlertTriangle, Layers, CheckSquare, BookOpen, FileSpreadsheet, Presentation, MapPin, Users, GitCompareArrows } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 type ViewTab = "dashboard" | "policies" | "findings" | "templates" | "baseline" | "cis" | "locations" | "personas" | "ms-learn";
+const MAX_OFFLINE_IMPORT_BYTES = 20 * 1024 * 1024; // 20MB
 
 export default function Home() {
   const isAuthenticated = useIsAuthenticated();
@@ -47,6 +50,87 @@ export default function Home() {
   const [hideMicrosoft, setHideMicrosoft] = useState(false);
   const [baselineCategory, setBaselineCategory] = useState<TemplateCategory | null>(null);
   const [logoBase64, setLogoBase64] = useState<string | null>(null);
+
+  const setAppMode = useCallback((mode: "offline" | "live") => {
+    localStorage.setItem("caAnalyzerMode", mode);
+    window.dispatchEvent(new CustomEvent("ca-analyzer-mode", { detail: mode }));
+  }, []);
+
+  const executeAnalysis = useCallback(async (ctx: TenantContext) => {
+    setContext(ctx);
+
+    setProgress("Analyzing policies…");
+    const analysisResult = analyzeAllPolicies(ctx);
+    setResult(analysisResult);
+
+    setProgress("Matching against policy templates…");
+    let activeTemplates = analyzeTemplates(ctx);
+    setTemplateResult(activeTemplates);
+
+    // Restore custom repo from previous session if saved
+    const savedRepoUrl = localStorage.getItem("customRepoUrl");
+    if (savedRepoUrl) {
+      setProgress("Restoring custom repo templates…");
+      // Saved value is either a plain URL string (legacy) or a JSON
+      // `{ url, fallbackUrl }` payload for layered baselines.
+      let parsedUrl = savedRepoUrl;
+      let parsedFallback: string | undefined;
+      if (savedRepoUrl.startsWith("{")) {
+        try {
+          const j = JSON.parse(savedRepoUrl) as { url?: string; fallbackUrl?: string };
+          if (j.url) parsedUrl = j.url;
+          parsedFallback = j.fallbackUrl;
+        } catch {
+          // Fall through and treat as a plain URL.
+        }
+      }
+      const custom = parsedFallback
+        ? await fetchLayeredGitHubTemplates(parsedUrl, parsedFallback)
+        : await fetchGitHubTemplates(parsedUrl);
+      if (custom.templates.length > 0) {
+        activeTemplates = analyzeTemplates(ctx, custom.templates);
+        setTemplateResult(activeTemplates);
+        setCustomRepoDisplay(custom.repoDisplay);
+      } else {
+        localStorage.removeItem("customRepoUrl");
+      }
+    }
+
+    setProgress("Running CIS alignment checks…");
+    const cis = runCISAlignment(ctx);
+    setCisResult(cis);
+
+    setProgress("Analyzing named locations…");
+    const locResult = analyzeNamedLocations(ctx);
+    setLocationResult(locResult);
+
+    setProgress("Scoring persona × control coverage…");
+    const persona = analyzePersonaCoverage(ctx);
+    setPersonaResult(persona);
+    // Merge persona-coverage findings into the main findings list so they
+    // surface in the Findings tab and exports without double-counting.
+    if (persona.findings.length > 0) {
+      const merged: AnalysisResult = {
+        ...analysisResult,
+        findings: [...analysisResult.findings, ...persona.findings],
+      };
+      setResult(merged);
+    }
+
+    setProgress("Computing security posture score…");
+    const composite = calculateCompositeScore(analysisResult, cis, activeTemplates);
+    setCompositeScore(composite);
+
+    setProgress("Scoring against Zero Trust pillars…");
+    const mergedForScorecard: AnalysisResult =
+      persona.findings.length > 0
+        ? { ...analysisResult, findings: [...analysisResult.findings, ...persona.findings] }
+        : analysisResult;
+    const zt = buildZeroTrustScorecard(ctx, mergedForScorecard, persona);
+    setScorecard(zt);
+
+    setActiveTab("dashboard");
+  }, []);
 
   /** Lazy-derived baseline gap report. Recomputes whenever templates or context change. */
   const baselineGapResult: BaselineGapResult | null = useMemo(() => {
@@ -92,80 +176,9 @@ export default function Home() {
     setError(null);
 
     try {
+      setAppMode("live");
       const ctx = await loadTenantContext(instance, accounts[0], setProgress);
-      setContext(ctx);
-
-      setProgress("Analyzing policies…");
-      const analysisResult = analyzeAllPolicies(ctx);
-      setResult(analysisResult);
-
-      setProgress("Matching against policy templates…");
-      let activeTemplates = analyzeTemplates(ctx);
-      setTemplateResult(activeTemplates);
-
-      // Restore custom repo from previous session if saved
-      const savedRepoUrl = localStorage.getItem("customRepoUrl");
-      if (savedRepoUrl) {
-        setProgress("Restoring custom repo templates…");
-        // Saved value is either a plain URL string (legacy) or a JSON
-        // `{ url, fallbackUrl }` payload for layered baselines.
-        let parsedUrl = savedRepoUrl;
-        let parsedFallback: string | undefined;
-        if (savedRepoUrl.startsWith("{")) {
-          try {
-            const j = JSON.parse(savedRepoUrl) as { url?: string; fallbackUrl?: string };
-            if (j.url) parsedUrl = j.url;
-            parsedFallback = j.fallbackUrl;
-          } catch {
-            // Fall through and treat as a plain URL.
-          }
-        }
-        const custom = parsedFallback
-          ? await fetchLayeredGitHubTemplates(parsedUrl, parsedFallback)
-          : await fetchGitHubTemplates(parsedUrl);
-        if (custom.templates.length > 0) {
-          activeTemplates = analyzeTemplates(ctx, custom.templates);
-          setTemplateResult(activeTemplates);
-          setCustomRepoDisplay(custom.repoDisplay);
-        } else {
-          localStorage.removeItem("customRepoUrl");
-        }
-      }
-
-      setProgress("Running CIS alignment checks…");
-      const cis = runCISAlignment(ctx);
-      setCisResult(cis);
-
-      setProgress("Analyzing named locations…");
-      const locResult = analyzeNamedLocations(ctx);
-      setLocationResult(locResult);
-
-      setProgress("Scoring persona × control coverage…");
-      const persona = analyzePersonaCoverage(ctx);
-      setPersonaResult(persona);
-      // Merge persona-coverage findings into the main findings list so they
-      // surface in the Findings tab and exports without double-counting.
-      if (persona.findings.length > 0) {
-        const merged: AnalysisResult = {
-          ...analysisResult,
-          findings: [...analysisResult.findings, ...persona.findings],
-        };
-        setResult(merged);
-      }
-
-      setProgress("Computing security posture score…");
-      const composite = calculateCompositeScore(analysisResult, cis, activeTemplates);
-      setCompositeScore(composite);
-
-      setProgress("Scoring against Zero Trust pillars…");
-      const mergedForScorecard: AnalysisResult =
-        persona.findings.length > 0
-          ? { ...analysisResult, findings: [...analysisResult.findings, ...persona.findings] }
-          : analysisResult;
-      const zt = buildZeroTrustScorecard(ctx, mergedForScorecard, persona);
-      setScorecard(zt);
-
-      setActiveTab("dashboard");
+      await executeAnalysis(ctx);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : "Unknown error occurred";
       setError(msg);
@@ -174,7 +187,43 @@ export default function Home() {
       setLoading(false);
       setProgress("");
     }
-  }, [instance, accounts]);
+  }, [instance, accounts, executeAnalysis, setAppMode]);
+
+  const handleLogin = useCallback(() => {
+    setAppMode("live");
+    instance.loginRedirect(loginRequest).catch((e) => {
+      console.error("Login failed:", e);
+    });
+  }, [instance, setAppMode]);
+
+  const handleOfflineImport = useCallback(async (file: File) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      setProgress("Parsing offline export…");
+      if (file.size > MAX_OFFLINE_IMPORT_BYTES) {
+        throw new Error(
+          `Offline export is too large (${Math.round(file.size / (1024 * 1024))}MB). Max supported size is 20MB.`
+        );
+      }
+      const text = await file.text();
+      const parsed = JSON.parse(text) as OfflineExportPayload;
+      const ctx = buildTenantContextFromOfflineExport(parsed);
+      if (ctx.policies.length === 0) {
+        throw new Error("No Conditional Access policies found in the uploaded JSON export.");
+      }
+      setAppMode("offline");
+      await executeAnalysis(ctx);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Failed to import offline export";
+      setError(msg);
+      console.error("Offline import failed:", e);
+    } finally {
+      setLoading(false);
+      setProgress("");
+    }
+  }, [executeAnalysis, setAppMode]);
 
   const exportResults = useCallback(() => {
     if (!result) return;
@@ -190,8 +239,8 @@ export default function Home() {
     URL.revokeObjectURL(url);
   }, [result, compositeScore]);
 
-  // ── Not Authenticated ─────────────────────────────────────────────────
-  if (!isAuthenticated) {
+  // ── Not Authenticated and no offline result yet ──────────────────────
+  if (!isAuthenticated && !result) {
     return (
       <div className="flex flex-col items-center justify-center py-32 text-center">
         <Shield className="h-16 w-16 text-blue-500 mb-6" />
@@ -199,8 +248,7 @@ export default function Home() {
           CA Policy Analyzer
         </h2>
         <p className="max-w-lg text-gray-400 mb-2">
-          Connect your Entra ID tenant to analyze Conditional Access policies
-          for best practices, FOCI token-sharing risks, and known bypasses.
+          Analyze Conditional Access policies for best practices, FOCI token-sharing risks, and known bypasses.
           Built on research by{" "}
           <a
             href="https://www.entrascopes.com"
@@ -211,22 +259,77 @@ export default function Home() {
             Fabian Bader / EntraScopes
           </a>.
         </p>
-        <p className="max-w-lg text-sm text-gray-600 mb-8">
-          Requires <code className="text-gray-400">Policy.Read.All</code>,{" "}
-          <code className="text-gray-400">Application.Read.All</code>, and{" "}
-          <code className="text-gray-400">Directory.Read.All</code> delegated
-          permissions.
-        </p>
-        <p className="text-sm text-gray-600">
-          Click <strong className="text-gray-400">Connect Tenant</strong> in the
-          header to get started.
-        </p>
+        <div className="mt-8 grid w-full max-w-4xl gap-4 text-left md:grid-cols-2">
+          <div className="rounded-xl border border-blue-500/30 bg-blue-500/5 p-5">
+            <div className="mb-2 inline-flex rounded-full border border-blue-500/30 bg-blue-500/10 px-2.5 py-1 text-xs font-medium text-blue-300">
+              Recommended
+            </div>
+            <p className="text-sm font-medium text-gray-100">Offline export import</p>
+            <p className="mt-1 text-xs text-gray-400">
+              Default mode for least privilege and fully offline analysis. Export once, then upload JSON.
+            </p>
+            <p className="mt-2 text-xs text-gray-500">
+              Limits: offline import supports JSON files up to 20MB.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <label
+                htmlFor="offline-import"
+                className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-500"
+              >
+                <Download className="h-4 w-4" />
+                Import Offline Export
+              </label>
+              <a
+                href="/offline-export"
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-700 px-3 py-2 text-sm text-gray-300 hover:bg-gray-800"
+              >
+                Offline Export Instructions
+              </a>
+            </div>
+            <input
+              id="offline-import"
+              type="file"
+              accept=".json,application/json"
+              className="hidden"
+              disabled={loading}
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) {
+                  void handleOfflineImport(file);
+                  e.target.value = "";
+                }
+              }}
+            />
+          </div>
+
+          <div className="rounded-xl border border-gray-800 bg-gray-900 p-5">
+            <p className="text-sm font-medium text-gray-200">Direct tenant connection</p>
+            <p className="mt-1 text-xs text-gray-500">
+              Connect live to Microsoft Graph for real-time reads using delegated permissions.
+            </p>
+            <p className="mt-2 text-xs text-gray-600">
+              Requires <code className="text-gray-400">Policy.Read.All</code>,{" "}
+              <code className="text-gray-400">Application.Read.All</code>, and{" "}
+              <code className="text-gray-400">Directory.Read.All</code>.
+            </p>
+            <p className="mt-4 text-xs text-gray-500">
+              Choose this when you want real-time tenant reads via Graph.
+            </p>
+            <button
+              onClick={handleLogin}
+              className="mt-4 inline-flex items-center gap-2 rounded-lg bg-gray-800 px-3 py-2 text-sm font-medium text-white hover:bg-gray-700"
+            >
+              <Play className="h-4 w-4" />
+              Connect Tenant
+            </button>
+          </div>
+        </div>
       </div>
     );
   }
 
   // ── Authenticated but not yet analyzed ────────────────────────────────
-  if (!result) {
+  if (isAuthenticated && !result) {
     return (
       <div className="flex flex-col items-center justify-center py-24 text-center">
         <Shield className="h-12 w-12 text-blue-500 mb-4" />
@@ -288,8 +391,12 @@ export default function Home() {
   ];
 
   // ── Results View ──────────────────────────────────────────────────────
-  const tenantName = context?.tenantDisplayName ?? accounts[0]?.username?.split("@")[1] ?? "Unknown";
+  const tenantName =
+    context?.tenantDisplayName ??
+    accounts[0]?.username?.split("@")[1] ??
+    "Unknown";
   const tenantId = context?.tenantId ?? accounts[0]?.tenantId ?? "";
+  if (!result) return null;
 
   return (
     <div className="space-y-6">
@@ -309,7 +416,7 @@ export default function Home() {
       </div>
 
       {/* Tab Bar + Actions */}
-      <div className="flex items-center justify-between gap-2">
+      <div className="space-y-2">
         {/* Scrollable tab strip — icons only on mobile, icons + labels on sm+ */}
         <div className="min-w-0 flex-1 overflow-x-auto scrollbar-hide">
           <div className="inline-flex gap-1 rounded-lg bg-gray-900 p-1">
@@ -336,7 +443,7 @@ export default function Home() {
         </div>
 
         {/* Action buttons — icon-only on mobile */}
-        <div className="flex shrink-0 gap-2">
+        <div className="flex flex-wrap gap-2">
           <button
             onClick={runAnalysis}
             disabled={loading}

--- a/src/lib/baseline-gap.ts
+++ b/src/lib/baseline-gap.ts
@@ -207,6 +207,8 @@ export function analyzeBaselineGaps(
 
   const buckets: PersonaGapBucket[] = [];
   for (const persona of PERSONA_ORDER) {
+    // We append unknown explicitly at the end so ordering is stable.
+    if (persona === "unknown") continue;
     const list = byPersona.get(persona) ?? [];
     if (list.length === 0) continue;
     const meta = PERSONA_META[persona];

--- a/src/lib/offline-import.ts
+++ b/src/lib/offline-import.ts
@@ -1,0 +1,442 @@
+import {
+  AuthenticationStrengthPolicy,
+  ConditionalAccessPolicy,
+  DirectoryObject,
+  NamedLocation,
+  ServicePrincipal,
+  TenantContext,
+  TenantLicenses,
+  inferLicensesFromPolicies,
+} from "./graph-client";
+
+type UnknownRecord = Record<string, unknown>;
+
+export interface OfflineExportPayload {
+  tenantId?: string;
+  tenantDisplayName?: string;
+  conditionalAccessPolicies?: unknown[];
+  policies?: unknown[];
+  namedLocations?: unknown[];
+  servicePrincipals?: unknown[];
+  directoryObjects?: unknown[];
+  authenticationStrengthPolicies?: unknown[];
+  authStrengthPolicies?: unknown[];
+  licenses?: Partial<TenantLicenses>;
+  subscribedSkus?: unknown[];
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === "string");
+}
+
+function toRecord(value: unknown): UnknownRecord {
+  return (value && typeof value === "object" ? value : {}) as UnknownRecord;
+}
+
+function isMeaningfulGuestExternalUsers(value: unknown): boolean {
+  const record = toRecord(value);
+  if (Object.keys(record).length === 0) return false;
+  const guestTypes = record.guestOrExternalUserTypes;
+  if (typeof guestTypes === "string" && guestTypes.trim().length > 0) return true;
+  const externalTenants = toRecord(record.externalTenants);
+  const membershipKind = externalTenants.membershipKind;
+  return typeof membershipKind === "string" && membershipKind.trim().length > 0;
+}
+
+function normalizeGrantAuthStrength(
+  value: unknown
+): { id: string; displayName: string } | undefined {
+  const record = toRecord(value);
+  const id = typeof record.id === "string" ? record.id : "";
+  const displayName =
+    typeof record.displayName === "string" ? record.displayName : "";
+  if (!id && !displayName) return undefined;
+  return { id, displayName };
+}
+
+function toCamelKey(key: string): string {
+  if (!key) return key;
+  if (key.startsWith("@") || key.startsWith("$")) return key;
+  return key[0].toLowerCase() + key.slice(1);
+}
+
+const MAX_NORMALIZE_DEPTH = 40;
+
+function normalizeKeysDeep(value: unknown, depth = 0): unknown {
+  if (depth > MAX_NORMALIZE_DEPTH) {
+    throw new Error(
+      `Offline export nesting exceeds safe limit (${MAX_NORMALIZE_DEPTH}).`
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => normalizeKeysDeep(v, depth + 1));
+  }
+  if (!value || typeof value !== "object") return value;
+  const input = value as UnknownRecord;
+  const out: UnknownRecord = {};
+  for (const [key, v] of Object.entries(input)) {
+    out[toCamelKey(key)] = normalizeKeysDeep(v, depth + 1);
+  }
+  return out;
+}
+
+function unwrapCollection(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  const record = toRecord(value);
+  if (Array.isArray(record.value)) return record.value;
+  // PowerShell exports may emit a single object rather than an array.
+  if (Object.keys(record).length > 0) return [record];
+  return [];
+}
+
+function normalizePolicy(input: unknown): ConditionalAccessPolicy | null {
+  const raw = toRecord(input);
+  const additionalProperties = toRecord(raw.additionalProperties);
+  const id = typeof raw.id === "string" ? raw.id : "";
+  const displayName = typeof raw.displayName === "string" ? raw.displayName : "";
+  if (!id || !displayName) return null;
+
+  const conditions = toRecord(raw.conditions);
+  const users = toRecord(conditions.users);
+  const applications = toRecord(conditions.applications);
+  const platforms = toRecord(conditions.platforms);
+  const locations = toRecord(conditions.locations);
+  const clientApplications = toRecord(conditions.clientApplications);
+  const authenticationFlows = toRecord(conditions.authenticationFlows);
+  const grantControls = toRecord(raw.grantControls);
+  const sessionControls = toRecord(raw.sessionControls);
+
+  return {
+    id,
+    templateId:
+      typeof raw.templateId === "string"
+        ? raw.templateId
+        : typeof additionalProperties.templateId === "string"
+          ? additionalProperties.templateId
+          : null,
+    displayName,
+    state:
+      raw.state === "enabled" ||
+      raw.state === "disabled" ||
+      raw.state === "enabledForReportingButNotEnforced"
+        ? raw.state
+        : "disabled",
+    createdDateTime:
+      typeof raw.createdDateTime === "string" ? raw.createdDateTime : "",
+    modifiedDateTime:
+      typeof raw.modifiedDateTime === "string" ? raw.modifiedDateTime : "",
+    conditions: {
+      users: {
+        includeUsers: asStringArray(users.includeUsers),
+        excludeUsers: asStringArray(users.excludeUsers),
+        includeGroups: asStringArray(users.includeGroups),
+        excludeGroups: asStringArray(users.excludeGroups),
+        includeRoles: asStringArray(users.includeRoles),
+        excludeRoles: asStringArray(users.excludeRoles),
+        includeGuestsOrExternalUsers: isMeaningfulGuestExternalUsers(
+          users.includeGuestsOrExternalUsers
+        )
+          ? users.includeGuestsOrExternalUsers
+          : undefined,
+        excludeGuestsOrExternalUsers: isMeaningfulGuestExternalUsers(
+          users.excludeGuestsOrExternalUsers
+        )
+          ? users.excludeGuestsOrExternalUsers
+          : undefined,
+      },
+      applications: {
+        includeApplications: asStringArray(applications.includeApplications),
+        excludeApplications: asStringArray(applications.excludeApplications),
+        includeUserActions: asStringArray(applications.includeUserActions),
+        includeAuthenticationContextClassReferences: asStringArray(
+          applications.includeAuthenticationContextClassReferences
+        ),
+        applicationFilter: applications.applicationFilter as
+          | { mode: string; rule: string }
+          | undefined,
+      },
+      clientAppTypes: asStringArray(conditions.clientAppTypes),
+      platforms:
+        Object.keys(platforms).length > 0
+          ? {
+              includePlatforms: asStringArray(platforms.includePlatforms),
+              excludePlatforms: asStringArray(platforms.excludePlatforms),
+            }
+          : undefined,
+      locations:
+        Object.keys(locations).length > 0
+          ? {
+              includeLocations: asStringArray(locations.includeLocations),
+              excludeLocations: asStringArray(locations.excludeLocations),
+            }
+          : undefined,
+      userRiskLevels: asStringArray(conditions.userRiskLevels),
+      signInRiskLevels: asStringArray(conditions.signInRiskLevels),
+      servicePrincipalRiskLevels: asStringArray(
+        conditions.servicePrincipalRiskLevels
+      ),
+      devices: conditions.devices as
+        | { deviceFilter?: { mode: string; rule: string } }
+        | undefined,
+      clientApplications:
+        Object.keys(clientApplications).length > 0
+          ? {
+              includeServicePrincipals: asStringArray(
+                clientApplications.includeServicePrincipals
+              ),
+              excludeServicePrincipals: asStringArray(
+                clientApplications.excludeServicePrincipals
+              ),
+              servicePrincipalFilter: clientApplications.servicePrincipalFilter as
+                | { mode: string; rule: string }
+                | undefined,
+            }
+          : undefined,
+      insiderRiskLevels:
+        typeof conditions.insiderRiskLevels === "string"
+          ? conditions.insiderRiskLevels
+          : undefined,
+      authenticationFlows:
+        Object.keys(authenticationFlows).length > 0
+          ? {
+              transferMethods:
+                typeof authenticationFlows.transferMethods === "string"
+                  ? authenticationFlows.transferMethods
+                  : undefined,
+            }
+          : undefined,
+    },
+    grantControls:
+      Object.keys(grantControls).length > 0
+        ? {
+            operator:
+              grantControls.operator === "AND" ? "AND" : "OR",
+            builtInControls: asStringArray(grantControls.builtInControls),
+            customAuthenticationFactors: asStringArray(
+              grantControls.customAuthenticationFactors
+            ),
+            termsOfUse: asStringArray(grantControls.termsOfUse),
+            authenticationStrength: normalizeGrantAuthStrength(
+              grantControls.authenticationStrength
+            ),
+          }
+        : undefined,
+    sessionControls:
+      Object.keys(sessionControls).length > 0
+        ? (sessionControls as ConditionalAccessPolicy["sessionControls"])
+        : undefined,
+  };
+}
+
+function normalizeNamedLocation(input: unknown): NamedLocation | null {
+  const raw = toRecord(input);
+  const additional = toRecord(raw.additionalProperties);
+  const id = typeof raw.id === "string" ? raw.id : "";
+  const displayName = typeof raw.displayName === "string" ? raw.displayName : "";
+  const odataType =
+    typeof raw["@odata.type"] === "string"
+      ? raw["@odata.type"]
+      : typeof additional["@odata.type"] === "string"
+        ? additional["@odata.type"]
+        : "#microsoft.graph.countryNamedLocation";
+  if (!id || !displayName) return null;
+  return {
+    id,
+    displayName,
+    "@odata.type": odataType,
+    isTrusted:
+      typeof raw.isTrusted === "boolean"
+        ? raw.isTrusted
+        : typeof additional.isTrusted === "boolean"
+          ? additional.isTrusted
+          : undefined,
+    ipRanges: Array.isArray(raw.ipRanges)
+      ? (raw.ipRanges as { cidrAddress: string }[])
+      : Array.isArray(additional.ipRanges)
+        ? (additional.ipRanges as { cidrAddress: string }[])
+      : undefined,
+    countriesAndRegions:
+      asStringArray(raw.countriesAndRegions).length > 0
+        ? asStringArray(raw.countriesAndRegions)
+        : asStringArray(additional.countriesAndRegions),
+    countryLookupMethod:
+      typeof raw.countryLookupMethod === "string"
+        ? raw.countryLookupMethod
+        : typeof additional.countryLookupMethod === "string"
+          ? additional.countryLookupMethod
+        : undefined,
+    includeUnknownCountriesAndRegions:
+      typeof raw.includeUnknownCountriesAndRegions === "boolean"
+        ? raw.includeUnknownCountriesAndRegions
+        : typeof additional.includeUnknownCountriesAndRegions === "boolean"
+          ? additional.includeUnknownCountriesAndRegions
+        : undefined,
+  };
+}
+
+function normalizeServicePrincipal(input: unknown): ServicePrincipal | null {
+  const raw = toRecord(input);
+  const id = typeof raw.id === "string" ? raw.id : "";
+  const appId = typeof raw.appId === "string" ? raw.appId : "";
+  const displayName = typeof raw.displayName === "string" ? raw.displayName : appId;
+  if (!id || !appId) return null;
+  return {
+    id,
+    appId,
+    displayName,
+    servicePrincipalType:
+      typeof raw.servicePrincipalType === "string"
+        ? raw.servicePrincipalType
+        : "Application",
+    appOwnerOrganizationId:
+      typeof raw.appOwnerOrganizationId === "string"
+        ? raw.appOwnerOrganizationId
+        : undefined,
+    tags: asStringArray(raw.tags),
+  };
+}
+
+function normalizeDirectoryObject(input: unknown): DirectoryObject | null {
+  const raw = toRecord(input);
+  const additional = toRecord(raw.additionalProperties);
+  const id = typeof raw.id === "string" ? raw.id : "";
+  if (!id) return null;
+  return {
+    id,
+    displayName:
+      typeof raw.displayName === "string"
+        ? raw.displayName
+        : typeof additional.displayName === "string"
+          ? additional.displayName
+          : id,
+    "@odata.type":
+      typeof raw["@odata.type"] === "string"
+        ? raw["@odata.type"]
+        : typeof additional["@odata.type"] === "string"
+          ? additional["@odata.type"]
+        : "unknown",
+  };
+}
+
+function normalizeAuthStrength(input: unknown): AuthenticationStrengthPolicy | null {
+  const raw = toRecord(input);
+  const id = typeof raw.id === "string" ? raw.id : "";
+  const displayName = typeof raw.displayName === "string" ? raw.displayName : "";
+  if (!id || !displayName) return null;
+  return {
+    id,
+    displayName,
+    description: typeof raw.description === "string" ? raw.description : "",
+    policyType:
+      raw.policyType === "builtIn" ||
+      raw.policyType === "custom" ||
+      raw.policyType === "unknownFutureValue"
+        ? raw.policyType
+        : "unknownFutureValue",
+    allowedCombinations: asStringArray(raw.allowedCombinations),
+    requirementsSatisfied:
+      raw.requirementsSatisfied === "none" ||
+      raw.requirementsSatisfied === "mfa" ||
+      raw.requirementsSatisfied === "unknownFutureValue"
+        ? raw.requirementsSatisfied
+        : "unknownFutureValue",
+  };
+}
+
+function inferLicensesFromSubscribedSkus(skus: unknown[]): TenantLicenses {
+  const planIds = new Set<string>();
+  for (const sku of skus) {
+    const rec = toRecord(sku);
+    const plans = asArray(rec.servicePlans);
+    for (const p of plans) {
+      const plan = toRecord(p);
+      if (typeof plan.servicePlanId === "string") {
+        planIds.add(plan.servicePlanId.toLowerCase());
+      }
+    }
+  }
+
+  const entraP1 = "41781fb2-bc02-4b7c-bd55-b576c07bb09d";
+  const entraP2 = "eec0eb4f-6444-4f95-aba0-50c24d67f998";
+  const intuneP1 = "c1ec4a95-1f05-45b3-a911-aa3fa01094f5";
+  const workloadP1 = "84c289f0-efcb-486f-8581-07f44fc9efad";
+  const workloadP2 = "7dc0e92d-bf15-401d-907e-0884efe7c760";
+
+  return {
+    hasEntraIdP1: planIds.has(entraP1) || planIds.has(entraP2),
+    hasEntraIdP2: planIds.has(entraP2),
+    hasIntunePlan1: planIds.has(intuneP1),
+    hasWorkloadIdPremium: planIds.has(workloadP1) || planIds.has(workloadP2),
+  };
+}
+
+export function buildTenantContextFromOfflineExport(
+  payload: OfflineExportPayload
+): TenantContext {
+  const normalized = normalizeKeysDeep(payload) as OfflineExportPayload;
+
+  const policiesRaw =
+    normalized.conditionalAccessPolicies ?? normalized.policies ?? [];
+  const policies = unwrapCollection(policiesRaw)
+    .map(normalizePolicy)
+    .filter((p): p is ConditionalAccessPolicy => p !== null);
+
+  const namedLocations = unwrapCollection(normalized.namedLocations)
+    .map(normalizeNamedLocation)
+    .filter((v): v is NamedLocation => v !== null);
+
+  const servicePrincipalsList = unwrapCollection(normalized.servicePrincipals)
+    .map(normalizeServicePrincipal)
+    .filter((v): v is ServicePrincipal => v !== null);
+  const servicePrincipals = new Map<string, ServicePrincipal>(
+    servicePrincipalsList.map((sp) => [sp.appId.toLowerCase(), sp])
+  );
+
+  const directoryObjectList = unwrapCollection(normalized.directoryObjects)
+    .map(normalizeDirectoryObject)
+    .filter((v): v is DirectoryObject => v !== null);
+  const directoryObjects = new Map<string, DirectoryObject>(
+    directoryObjectList.map((obj) => [obj.id, obj])
+  );
+
+  const authStrengthList = asArray(
+    normalized.authenticationStrengthPolicies ?? normalized.authStrengthPolicies
+  )
+    .map(normalizeAuthStrength)
+    .filter((v): v is AuthenticationStrengthPolicy => v !== null);
+  const authStrengthPolicies = new Map<string, AuthenticationStrengthPolicy>(
+    authStrengthList.map((a) => [a.id, a])
+  );
+
+  const tenantId = normalized.tenantId ?? "";
+  const tenantDisplayName =
+    normalized.tenantDisplayName ??
+    (tenantId ? `Offline Tenant (${tenantId})` : "Offline Tenant");
+
+  const licenses: TenantLicenses = normalized.licenses
+    ? {
+        hasEntraIdP1: Boolean(normalized.licenses.hasEntraIdP1),
+        hasEntraIdP2: Boolean(normalized.licenses.hasEntraIdP2),
+        hasIntunePlan1: Boolean(normalized.licenses.hasIntunePlan1),
+        hasWorkloadIdPremium: Boolean(normalized.licenses.hasWorkloadIdPremium),
+      }
+    : unwrapCollection(normalized.subscribedSkus).length > 0
+      ? inferLicensesFromSubscribedSkus(unwrapCollection(normalized.subscribedSkus))
+      : inferLicensesFromPolicies(policies);
+
+  return {
+    tenantDisplayName,
+    tenantId,
+    policies,
+    namedLocations,
+    servicePrincipals,
+    directoryObjects,
+    licenses,
+    authStrengthPolicies,
+  };
+}


### PR DESCRIPTION
In some scenarios it's easier to get an offline extract of the required rules/data than having the tool run against the tenant.

This PR introduces an offline mode — allowing you to export your Conditional Access policies via PowerShell and upload the JSON for full analysis, without requiring direct tenant connectivity or Azure AD permissions in the browser. It also allows point in time comparisons between different exports. I understand there is a large amount of code change in this PR, but think it's a worthwhile feature to add.

**What's included**
Offline import parser (offline-import.ts)
A purpose-built parser with broad Graph PowerShell v2/Beta compatibility — handles PascalCase keys, AdditionalProperties, single-object collections, null array fields, and null guest/auth-strength placeholders that real-world exports produce.

**Offline Export Guide (/offline-export)**
A new in-app guide page with step-by-step PowerShell export instructions using the Graph PowerShell v2 Beta module.

**Redesigned opening screen**
Two explicit paths — Offline export import and Direct tenant connection — so the workflow is clear from the start. The header shows an "Offline mode" indicator once an import is active, and clears automatically when returning to the home screen.

**Security hardening**
20 MB file size limit enforced before parsing
40-level recursion depth guard in key normalisation
Offline import results no longer gated behind authentication


**How to export your policies**
Connect-MgGraph -Scopes "Policy.Read.All"
Get-MgIdentityConditionalAccessPolicy | ConvertTo-Json -Depth 10 | Out-File ca-export.json
Then upload ca-export.json via the Offline export import path on the opening screen.

Please note that Claude Sonnet was used to generate a vast majority of the code in this PR.